### PR TITLE
Add build test workflow

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,33 @@
+# Workflow to build the repository and confirm success.
+
+name: Test Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**.md'
+      - '**.js'
+      - '**.mjs'
+      - '**.ts'
+      - '**.tsx'
+      - '**.scss'
+      - 'src/**.css'
+      - 'package-lock.json'
+      - 'package.json'
+      - .github/workflows/build.yml
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "testbuild"
+
+jobs:
+  test_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/node-npm-setup
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
### What's being changed

I am adding a test build workflow file which will be useful for branch protection rules.

Closes: 

N/A

### Notes

It may be inefficient or otherwise bad practice to have a build test. I haven't seen it in practice. However, I think it's useful when we want pull requests checks against the build process without deploying the build.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.
- [x] I've worked through build failures and tests are passing.
