### PR TITLE
Set version number due to error in CI

### DIFF
--- a/.github/workflows/move-ready-to-merge-pr.yml
+++ b/.github/workflows/move-ready-to-merge-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: remove label
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@1.0.4
         with:
           ignore-if-assigned: 'false'
           remove-labels: 'waiting for review'

--- a/.github/workflows/triage-issue-comments.yml
+++ b/.github/workflows/triage-issue-comments.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Label issues with new comments with 'triage'
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@1.0.4
         with:
           add-labels: 'triage'
           ignore-if-labeled: true

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
       - name: Label new issues with 'triage'
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@1.0.4
         with:
           add-labels: 'triage'

--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -21,6 +21,6 @@ jobs:
 
     steps:
       - name: Label new pull requests with 'triage'
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@1.0.4
         with:
           add-labels: 'triage'


### PR DESCRIPTION
### What's being changed

I have replaced the hash version number with the latest version number for the action package.

Closes: 


N/A

### Notes

The labeler action's repository is archived but is being used by GitHub Docs with the previously used hash.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.
- [x] I've worked through build failures and tests are passing.
