### PR TITLE
Restrict workflow to only post a thank you message for users other than the repo owner

### DIFF
--- a/.github/workflows/merged-notification.yml
+++ b/.github/workflows/merged-notification.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   comment:
-    if: github.repository == 'zachwatkins/.github' && github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
+    if: github.repository == 'zachwatkins/.github' && github.actor != 'zachwatkins' && github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
### What's being changed

I've added a conditional statement which allows the workflow to avoid being dispatched if the pull request is submitted by me. It's weird to thank myself but it's essential to thank others.