### PR TITLE
Expand scope of workflow file to all repositories I own

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   triage:
-    if: ${{ github.repository == 'zachwatkins/.github' }}
+    if: github.repository_owner == 'zachwatkins'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### What's being changed

This change expands the scope of a reusable workflow file to allow it to run on all repositories I own. This change was needed to allow my new `wordpress-theme` repository to reuse it.