### PR TITLE
Explicitly check out this repository in calling workflows

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: 'zachwatkins/.github'
       - uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What's being changed

The workflow which labels pull requests is still experiencing an HTTP error in the labeler action package in the `zachwatkins/wordpress-theme` repository. This pull request attempts to correct that by explicitly checking out this repository in calling workflows.