### PR TITLE
Address error in other repository with missing shell property

### DIFF
--- a/.github/actions/php-composer-setup/action.yml
+++ b/.github/actions/php-composer-setup/action.yml
@@ -9,6 +9,7 @@ runs:
     - name: Get composer cache directory
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: Cache dependencies
       uses: actions/cache@v3
@@ -19,3 +20,4 @@ runs:
 
     - name: Install dependencies
       run: composer install --no-progress --no-suggest --prefer-dist --no-interaction
+      shell: bash


### PR DESCRIPTION
### What's being changed

This pull request addresses an error found when calling this workflow file in another repository. See: https://github.com/ZachWatkins/wordpress-theme/actions/runs/5503504590/jobs/10028763536?pr=13